### PR TITLE
minor tweaks to reuse existing code

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -47,11 +47,12 @@ msg = dedent(
         %(pip_cmd)s install -e ".[testing]"
 
     Migrate the database using Alembic.
-        # Generate revisions.
+        # Generate your first revision.
         %(alembic_cmd)s -c development.ini revision --autogenerate -m "init"
         # Upgrade to that revision.
         %(alembic_cmd)s -c development.ini upgrade head
-        # Later you can run database migrations.
+        # Load default data.
+        %(init_cmd)s development.ini
 
     Run your project's tests.
         %(pytest_cmd)s

--- a/{{cookiecutter.repo_name}}/README.txt
+++ b/{{cookiecutter.repo_name}}/README.txt
@@ -20,17 +20,19 @@ Getting Started
 
     env/bin/pip install -e ".[testing]"
 
-- Migrate the database using Alembic.
+- Initialize the database using Alembic.
 
-    - Generate revisions.
+    - Generate your first revision.
 
         env/bin/alembic -c development.ini revision --autogenerate -m "init"
 
     - Upgrade to that revision.
 
         env/bin/alembic -c development.ini upgrade head
-    
-    - Later you can run database migrations.
+
+    - Load default data.
+
+        env/bin/initialize_{{ cookiecutter.repo_name }}_db development.ini
 
 - Run your project's tests.
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/alembic/env.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/alembic/env.py
@@ -1,8 +1,8 @@
 """Pyramid bootstrap environment. """
+from alembic import context
 from pyramid.paster import get_appsettings, setup_logging
 
-from alembic import context
-from sqlalchemy import engine_from_config
+from {{ cookiecutter.repo_name }}.models import get_engine
 from {{ cookiecutter.repo_name }}.models.meta import Base
 
 config = context.config
@@ -25,7 +25,7 @@ def run_migrations_offline():
     script output.
 
     """
-    context.configure(url=settings.get('sqlalchemy.url'))
+    context.configure(url=settings['sqlalchemy.url'])
     with context.begin_transaction():
         context.run_migrations()
 
@@ -37,9 +37,7 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
-    # specify here how the engine is acquired
-    # engine = meta.engine
-    engine = engine_from_config(settings, 'sqlalchemy.')
+    engine = get_engine(settings)
 
     connection = engine.connect()
     context.configure(


### PR DESCRIPTION
extends https://github.com/Pylons/pyramid-cookiecutter-alchemy/pull/7

- drop `parse_vars`, with the new plaster loader it's possible to pass in options to your config file using a query string such as `development.ini?http_port=5000`.

- use an explicit transaction manager

- don't use `.get` on a dict unless it's really optional

- re-use `get_engine` instead of `engine_from_config`